### PR TITLE
Add analytics and optimization features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+IBKR_CLIENT_ID=your_client_id
+IBKR_CLIENT_SECRET=your_client_secret
+DATABASE_URL=postgresql://postgres:postgres@db:5432/portfolio
+NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 IBKR_CLIENT_ID=your_client_id
 IBKR_CLIENT_SECRET=your_client_secret
+DEMO_MODE=true
 DATABASE_URL=postgresql://postgres:postgres@db:5432/portfolio
 NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+node_modules/
+.env
+pytest_cache/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Modular and extensible dashboard for tracking portfolios, analyzing data, and ru
 
 ## Getting Started
 1. Copy `.env.example` to `.env` and fill in credentials.
+   - Leave `DEMO_MODE=true` to explore the app with an example portfolio. Set it to `false` and supply IBKR keys to connect to a real account.
 2. Build and run all services:
    ```bash
    docker-compose up --build
@@ -35,4 +36,4 @@ backend/    # FastAPI application and ingestion stubs
 frontend/   # Next.js dashboard UI
 ```
 
-IBKR connectivity is represented with mock data in `backend/app/ibkr.py`. Replace with real API calls and add analytics or optimization logic as needed.
+IBKR connectivity is represented with mock data in `backend/app/ibkr.py`. Replace with real API calls and disable demo mode when ready to connect to a live account.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
-# dashboard
-portfolio dashboard
+# Portfolio Dashboard
+
+Modular and extensible dashboard for tracking portfolios, analyzing data, and running optimizations.
+
+## Architecture
+- **Frontend:** Next.js (React) with TailwindCSS
+- **Backend:** FastAPI (Python) with PostgreSQL and Redis
+- **Analytics:** Risk metrics, correlations, efficient frontier via PyPortfolioOpt
+- **Charts:** Recharts, Plotly.js, D3.js
+- **Deployment:** Docker and docker-compose
+
+## Getting Started
+1. Copy `.env.example` to `.env` and fill in credentials.
+2. Build and run all services:
+   ```bash
+   docker-compose up --build
+   ```
+3. Frontend available at `http://localhost:3000`
+4. Backend API available at `http://localhost:8000/api/holdings`
+5. Analytics endpoint at `http://localhost:8000/api/analytics`
+6. Optimization endpoint at `http://localhost:8000/api/optimization`
+
+## Testing
+
+Run backend and frontend tests after changes:
+
+```bash
+python -m pytest
+npm --prefix frontend test
+```
+
+## Project Structure
+```
+backend/    # FastAPI application and ingestion stubs
+frontend/   # Next.js dashboard UI
+```
+
+IBKR connectivity is represented with mock data in `backend/app/ibkr.py`. Replace with real API calls and add analytics or optimization logic as needed.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/analytics.py
+++ b/backend/app/analytics.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pandas as pd
+from .data import sample_price_data
+
+
+def compute_metrics() -> dict:
+    """Calculate basic portfolio risk metrics."""
+    prices = sample_price_data()
+    returns = prices.pct_change().dropna()
+    mean_returns = returns.mean()
+    volatility = returns.std()
+    sharpe = (mean_returns.mean() / volatility.mean()) * np.sqrt(252)
+    corr = returns.corr()
+    return {
+        "sharpe": float(sharpe),
+        "volatility": float(volatility.mean()),
+        "tickers": list(corr.columns),
+        "correlation": corr.values.tolist(),
+    }

--- a/backend/app/data.py
+++ b/backend/app/data.py
@@ -1,0 +1,12 @@
+import pandas as pd
+
+
+def sample_price_data() -> pd.DataFrame:
+    """Return mock price history for demo purposes."""
+    data = {
+        "AAPL": [150, 152, 154, 153, 155],
+        "MSFT": [300, 305, 310, 308, 312],
+        "GOOG": [2700, 2725, 2730, 2740, 2755],
+    }
+    dates = pd.date_range(end=pd.Timestamp.today(), periods=5)
+    return pd.DataFrame(data, index=dates)

--- a/backend/app/ibkr.py
+++ b/backend/app/ibkr.py
@@ -1,0 +1,11 @@
+"""Placeholder functions for Interactive Brokers and market data APIs."""
+
+from .schemas import Holding
+
+
+def get_mock_holdings() -> list[Holding]:
+    """Return sample holdings for demo purposes."""
+    return [
+        Holding(symbol="AAPL", quantity=10, cost_basis=150.0, price=170.0),
+        Holding(symbol="MSFT", quantity=5, cost_basis=250.0, price=300.0),
+    ]

--- a/backend/app/ibkr.py
+++ b/backend/app/ibkr.py
@@ -1,11 +1,30 @@
-"""Placeholder functions for Interactive Brokers and market data APIs."""
+"""Placeholder functions for Interactive Brokers and market data APIs.
+
+This module exposes a ``get_holdings`` function that returns an example
+portfolio when the application runs in demo mode.  Supplying IBKR API
+credentials and disabling demo mode is reserved for future work.
+"""
+
+from __future__ import annotations
+
+import os
 
 from .schemas import Holding
 
 
-def get_mock_holdings() -> list[Holding]:
+def get_demo_holdings() -> list[Holding]:
     """Return sample holdings for demo purposes."""
     return [
         Holding(symbol="AAPL", quantity=10, cost_basis=150.0, price=170.0),
         Holding(symbol="MSFT", quantity=5, cost_basis=250.0, price=300.0),
+        Holding(symbol="GOOG", quantity=2, cost_basis=2000.0, price=2750.0),
     ]
+
+
+def get_holdings() -> list[Holding]:
+    """Return holdings from IBKR or fall back to demo data."""
+    if os.getenv("DEMO_MODE", "true").lower() == "true":
+        return get_demo_holdings()
+
+    # Placeholder for real IBKR API integration
+    raise NotImplementedError("IBKR API integration not implemented yet")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,49 @@
+from fastapi import FastAPI, WebSocket
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+import os
+
+from . import models, schemas, ibkr
+from .analytics import compute_metrics
+from .optimization import efficient_frontier_points
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@db:5432/portfolio")
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Portfolio Dashboard API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.get("/api/holdings", response_model=list[schemas.Holding])
+def read_holdings():
+    """Return current portfolio holdings."""
+    return ibkr.get_mock_holdings()
+
+@app.websocket("/ws/updates")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    # Placeholder for pushing real-time updates
+    await websocket.send_text("update")
+    await websocket.close()
+
+
+@app.get("/api/analytics", response_model=schemas.Analytics)
+def analytics():
+    """Return basic risk metrics and correlations."""
+    return compute_metrics()
+
+
+@app.get("/api/optimization", response_model=list[schemas.FrontierPoint])
+def optimization():
+    """Return efficient frontier points."""
+    return efficient_frontier_points()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,7 +27,7 @@ app.add_middleware(
 @app.get("/api/holdings", response_model=list[schemas.Holding])
 def read_holdings():
     """Return current portfolio holdings."""
-    return ibkr.get_mock_holdings()
+    return ibkr.get_holdings()
 
 @app.websocket("/ws/updates")
 async def websocket_endpoint(websocket: WebSocket):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, String, Float
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+
+
+class Holding(Base):
+    __tablename__ = "holdings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    symbol = Column(String, index=True)
+    quantity = Column(Integer)
+    cost_basis = Column(Float)
+    price = Column(Float)

--- a/backend/app/optimization.py
+++ b/backend/app/optimization.py
@@ -1,0 +1,22 @@
+import numpy as np
+from pypfopt import EfficientFrontier, expected_returns, risk_models
+from .data import sample_price_data
+
+
+def efficient_frontier_points(n_points: int = 20) -> list[dict]:
+    """Approximate efficient frontier using PyPortfolioOpt."""
+    prices = sample_price_data()
+    mu = expected_returns.mean_historical_return(prices)
+    S = risk_models.sample_cov(prices)
+    ef_min = EfficientFrontier(mu, S, solver="SCS")
+    ef_min.min_volatility()
+    ret_min, vol_min, _ = ef_min.portfolio_performance()
+    ef_max = EfficientFrontier(mu, S, solver="SCS")
+    ef_max.max_sharpe()
+    ret_max, vol_max, _ = ef_max.portfolio_performance()
+    risks = np.linspace(vol_min, vol_max, n_points)
+    rets = np.linspace(ret_min, ret_max, n_points)
+    return [
+        {"risk": float(r), "return": float(ret)}
+        for r, ret in zip(risks, rets)
+    ]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, Field
+
+
+class Holding(BaseModel):
+    symbol: str
+    quantity: int
+    cost_basis: float
+    price: float
+
+    class Config:
+        orm_mode = True
+
+
+class Analytics(BaseModel):
+    sharpe: float
+    volatility: float
+    tickers: list[str]
+    correlation: list[list[float]]
+
+
+class FrontierPoint(BaseModel):
+    risk: float
+    expected_return: float = Field(..., alias="return")
+
+    class Config:
+        allow_population_by_field_name = True

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn[standard]
+sqlalchemy
+psycopg2-binary
+pydantic
+pandas
+numpy
+pyportfolioopt
+httpx

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_holdings():
+    r = client.get("/api/holdings")
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
+
+
+def test_analytics():
+    r = client.get("/api/analytics")
+    assert r.status_code == 200
+    data = r.json()
+    assert "sharpe" in data and "correlation" in data
+
+
+def test_optimization():
+    r = client.get("/api/optimization")
+    assert r.status_code == 200
+    data = r.json()
+    assert isinstance(data, list)
+    assert data and "risk" in data[0] and "return" in data[0]

--- a/backend/tests/test_endpoints.py
+++ b/backend/tests/test_endpoints.py
@@ -12,7 +12,11 @@ client = TestClient(app)
 def test_holdings():
     r = client.get("/api/holdings")
     assert r.status_code == 200
-    assert isinstance(r.json(), list)
+    data = r.json()
+    assert isinstance(data, list)
+    # demo mode should return example positions
+    assert len(data) >= 3
+    assert {h["symbol"] for h in data} >= {"AAPL", "MSFT", "GOOG"}
 
 
 def test_analytics():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     build: ./backend
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/portfolio
+      - DEMO_MODE=${DEMO_MODE-true}
     depends_on:
       - db
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.9'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: portfolio
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  backend:
+    build: ./backend
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/portfolio
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+  frontend:
+    build: ./frontend
+    depends_on:
+      - backend
+    ports:
+      - "3000:3000"
+volumes:
+  postgres-data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+
+WORKDIR /app
+COPY package.json .
+RUN npm install
+COPY . .
+RUN npm run build
+CMD ["npm", "run", "start"]

--- a/frontend/components/Analytics.tsx
+++ b/frontend/components/Analytics.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react'
+
+type AnalyticsData = {
+  sharpe: number
+  volatility: number
+  tickers: string[]
+  correlation: number[][]
+}
+
+export default function Analytics() {
+  const [data, setData] = useState<AnalyticsData | null>(null)
+
+  useEffect(() => {
+    const base = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+    fetch(`${base}/api/analytics`)
+      .then((res) => res.json())
+      .then(setData)
+  }, [])
+
+  if (!data) return <div>Loading...</div>
+
+  return (
+    <div>
+      <p>Sharpe Ratio: {data.sharpe.toFixed(2)}</p>
+      <p>Volatility: {(data.volatility * 100).toFixed(2)}%</p>
+      <table className="table-auto border mt-4">
+        <thead>
+          <tr>
+            <th></th>
+            {data.tickers.map((t) => (
+              <th key={t}>{t}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.tickers.map((row, i) => (
+            <tr key={row}>
+              <td>{row}</td>
+              {data.correlation[i].map((c, j) => (
+                <td key={j}>{c.toFixed(2)}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/components/OptimizationChart.tsx
+++ b/frontend/components/OptimizationChart.tsx
@@ -1,0 +1,33 @@
+import dynamic from 'next/dynamic'
+import { useEffect, useState } from 'react'
+
+const Plot = dynamic(() => import('react-plotly.js'), { ssr: false })
+
+type Point = { risk: number; return: number }
+
+export default function OptimizationChart() {
+  const [points, setPoints] = useState<Point[]>([])
+
+  useEffect(() => {
+    const base = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+    fetch(`${base}/api/optimization`)
+      .then((res) => res.json())
+      .then(setPoints)
+  }, [])
+
+  if (!points.length) return <div>Loading...</div>
+
+  return (
+    <Plot
+      data={[
+        {
+          x: points.map((p) => p.risk),
+          y: points.map((p) => p.return),
+          mode: 'lines+markers',
+          name: 'Efficient Frontier',
+        },
+      ]}
+      layout={{ title: 'Efficient Frontier', xaxis: { title: 'Risk' }, yaxis: { title: 'Return' } }}
+    />
+  )
+}

--- a/frontend/components/Snapshot.tsx
+++ b/frontend/components/Snapshot.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react'
+
+type Holding = {
+  symbol: string
+  quantity: number
+  cost_basis: number
+  price: number
+}
+
+type EnrichedHolding = Holding & {
+  value: number
+  pnl: number
+}
+
+export default function Snapshot() {
+  const [holdings, setHoldings] = useState<EnrichedHolding[]>([])
+
+  useEffect(() => {
+    const base = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+    fetch(`${base}/api/holdings`)
+      .then((res) => res.json())
+      .then((data: Holding[]) => {
+        const enriched = data.map((h) => ({
+          ...h,
+          value: h.price * h.quantity,
+          pnl: (h.price - h.cost_basis) * h.quantity,
+        }))
+        setHoldings(enriched)
+      })
+  }, [])
+
+  if (!holdings.length) return <div>Loading...</div>
+
+  const totalValue = holdings.reduce((sum, h) => sum + h.value, 0)
+  const totalPnl = holdings.reduce((sum, h) => sum + h.pnl, 0)
+
+  return (
+    <div>
+      <p className="mb-2">Portfolio Value: ${totalValue.toFixed(2)}</p>
+      <p className="mb-4">Total P&L: ${totalPnl.toFixed(2)}</p>
+      <table className="table-auto border">
+        <thead>
+          <tr>
+            <th className="px-2">Symbol</th>
+            <th className="px-2">Qty</th>
+            <th className="px-2">Cost Basis</th>
+            <th className="px-2">Price</th>
+            <th className="px-2">Value</th>
+            <th className="px-2">P&amp;L</th>
+          </tr>
+        </thead>
+        <tbody>
+          {holdings.map((h) => (
+            <tr key={h.symbol}>
+              <td className="px-2">{h.symbol}</td>
+              <td className="px-2">{h.quantity}</td>
+              <td className="px-2">${h.cost_basis.toFixed(2)}</td>
+              <td className="px-2">${h.price.toFixed(2)}</td>
+              <td className="px-2">${h.value.toFixed(2)}</td>
+              <td className="px-2">${h.pnl.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/components/Tabs.tsx
+++ b/frontend/components/Tabs.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import Analytics from './Analytics'
 import OptimizationChart from './OptimizationChart'
+import Snapshot from './Snapshot'
 
 const tabs = ['Current Snapshot', 'Data Analysis & Insights', 'Portfolio Optimization']
 
@@ -20,7 +21,7 @@ export default function Tabs() {
         ))}
       </div>
       <div>
-        {active === 0 && <div>Real-time snapshot goes here.</div>}
+        {active === 0 && <Snapshot />}
         {active === 1 && <Analytics />}
         {active === 2 && <OptimizationChart />}
       </div>

--- a/frontend/components/Tabs.tsx
+++ b/frontend/components/Tabs.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+import Analytics from './Analytics'
+import OptimizationChart from './OptimizationChart'
+
+const tabs = ['Current Snapshot', 'Data Analysis & Insights', 'Portfolio Optimization']
+
+export default function Tabs() {
+  const [active, setActive] = useState(0)
+  return (
+    <div>
+      <div className="flex space-x-4 border-b mb-4">
+        {tabs.map((t, idx) => (
+          <button
+            key={t}
+            className={`pb-2 ${active === idx ? 'border-b-2 border-blue-500' : ''}`}
+            onClick={() => setActive(idx)}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+      <div>
+        {active === 0 && <div>Real-time snapshot goes here.</div>}
+        {active === 1 && <Analytics />}
+        {active === 2 && <OptimizationChart />}
+      </div>
+    </div>
+  )
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  reactStrictMode: true,
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "portfolio-dashboard-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "^3.3.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "recharts": "^2.8.0",
+    "plotly.js": "^2.25.2",
+    "d3": "^7.8.5",
+    "react-plotly.js": "^2.5.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.4"
+  }
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,6 @@
+import '../styles/globals.css'
+import type { AppProps } from 'next/app'
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,16 @@
+import Head from 'next/head'
+import Tabs from '../components/Tabs'
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>Portfolio Dashboard</title>
+      </Head>
+      <main className="p-4">
+        <h1 className="text-2xl font-bold mb-4">Portfolio Dashboard</h1>
+        <Tabs />
+      </main>
+    </>
+  )
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./pages/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- compute risk metrics and correlations via new `/api/analytics` endpoint
- approximate efficient frontier with PyPortfolioOpt via `/api/optimization`
- visualize analytics and optimization in React tabs using Plotly
- document running backend and frontend tests in README

## Testing
- `python -m pytest`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b066cb9483238b36518da0281d60